### PR TITLE
Testing

### DIFF
--- a/lib/orm/decorators/column.decorator.ts
+++ b/lib/orm/decorators/column.decorator.ts
@@ -4,7 +4,7 @@ import { addAttribute, addOptions, getOptions } from '../utils/decorator.utils';
 import { BeforeSave } from './listeners';
 
 export function Column(options: ColumnOptions): PropertyDecorator {
-  return (target: object, propertyName: string) => {
+  return (target: Function, propertyName: string) => {
     addAttribute(target, propertyName, options);
   };
 }
@@ -12,7 +12,7 @@ export function Column(options: ColumnOptions): PropertyDecorator {
 export function GeneratedUUidColumn(
   type: 'uuid' | 'timeuuid' = 'uuid',
 ): PropertyDecorator {
-  return (target: object, propertyName: string) => {
+  return (target: Function, propertyName: string) => {
     const fn: PropertyDescriptor = {
       value: (...args: any[]) => {
         const instance = args[0];
@@ -31,13 +31,13 @@ export function GeneratedUUidColumn(
 }
 
 export function VersionColumn(): PropertyDecorator {
-  return (target: object, propertyName: string) => {
+  return (target: Function, propertyName: string) => {
     addOptions(target, { options: { versions: { key: propertyName } } });
   };
 }
 
 export function CreateDateColumn(): PropertyDecorator {
-  return (target: object, propertyName: string) => {
+  return (target: Function, propertyName: string) => {
     addOptions(target, {
       options: { timestamps: { createdAt: propertyName } },
     });
@@ -45,7 +45,7 @@ export function CreateDateColumn(): PropertyDecorator {
 }
 
 export function UpdateDateColumn(): PropertyDecorator {
-  return (target: object, propertyName: string) => {
+  return (target: Function, propertyName: string) => {
     addOptions(target, {
       options: { timestamps: { updatedAt: propertyName } },
     });
@@ -53,7 +53,7 @@ export function UpdateDateColumn(): PropertyDecorator {
 }
 
 export function IndexColumn(): PropertyDecorator {
-  return (target: object, propertyName: string) => {
+  return (target: Function, propertyName: string) => {
     let { indexes } = getOptions(target);
     indexes = indexes || [];
 

--- a/lib/orm/decorators/entity-method.decorator.ts
+++ b/lib/orm/decorators/entity-method.decorator.ts
@@ -1,8 +1,8 @@
-import { getOptions, addOptions } from '../utils/decorator.utils';
+import { addOptions, getOptions } from '../utils/decorator.utils';
 
 export function EntityMethod(): MethodDecorator {
   return (
-    target: object,
+    target: Function,
     propertyKey: string,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {

--- a/lib/orm/decorators/entity.decorator.ts
+++ b/lib/orm/decorators/entity.decorator.ts
@@ -1,3 +1,4 @@
+import pluralize from 'pluralize';
 import { pascalToSnakeCase } from '../../utils/string';
 import { EntityOptions } from '../interfaces';
 import { addOptions, setEntityName } from '../utils/decorator.utils';
@@ -11,6 +12,17 @@ export function Entity(
   nameOrOptions?: string | EntityOptions,
   maybeOptions?: EntityOptions,
 ): ClassDecorator {
+  // Add validation
+  if (
+    typeof nameOrOptions === 'string' &&
+    maybeOptions &&
+    maybeOptions.table_name
+  ) {
+    throw new Error(
+      'Cannot specify table name in both parameters. Use either string parameter or options.table_name, not both.',
+    );
+  }
+
   const options: any =
     (typeof nameOrOptions === 'object'
       ? (nameOrOptions as EntityOptions)
@@ -20,12 +32,12 @@ export function Entity(
     const name =
       typeof nameOrOptions === 'string'
         ? nameOrOptions
-        : options.table_name || pascalToSnakeCase(target.name);
+        : options.table_name || pluralize(pascalToSnakeCase(target.name));
 
     options.instanceMethods = target.prototype;
     options.classMethods = target;
 
-    setEntityName(target.prototype, name);
-    addOptions(target.prototype, options);
+    setEntityName(target, name);
+    addOptions(target, options);
   };
 }

--- a/lib/orm/decorators/listeners/after-delete.decorator.ts
+++ b/lib/orm/decorators/listeners/after-delete.decorator.ts
@@ -7,7 +7,7 @@ import {
 
 export function AfterDelete(): MethodDecorator {
   return (
-    target: object,
+    target: Function,
     propertyKey: string | Symbol,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {

--- a/lib/orm/decorators/listeners/after-save.decorator.ts
+++ b/lib/orm/decorators/listeners/after-save.decorator.ts
@@ -7,7 +7,7 @@ import {
 
 export function AfterSave(): MethodDecorator {
   return (
-    target: object,
+    target: Function,
     propertyKey: string | Symbol,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {

--- a/lib/orm/decorators/listeners/after-update.decorator.ts
+++ b/lib/orm/decorators/listeners/after-update.decorator.ts
@@ -7,7 +7,7 @@ import {
 
 export function AfterUpdate(): MethodDecorator {
   return (
-    target: object,
+    target: Function,
     propertyKey: string | Symbol,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {

--- a/lib/orm/decorators/listeners/before-delete.decorator.ts
+++ b/lib/orm/decorators/listeners/before-delete.decorator.ts
@@ -7,7 +7,7 @@ import {
 
 export function BeforeDelete(): MethodDecorator {
   return (
-    target: object,
+    target: Function,
     propertyKey: string | Symbol,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {

--- a/lib/orm/decorators/listeners/before-save.decorator.ts
+++ b/lib/orm/decorators/listeners/before-save.decorator.ts
@@ -1,13 +1,13 @@
 import { BEFORE_SAVE } from '../../orm.constant';
 import {
-  addOptions,
   addHookFunction,
+  addOptions,
   getOptions,
 } from '../../utils/decorator.utils';
 
 export function BeforeSave(): MethodDecorator {
   return (
-    target: object,
+    target: Function,
     propertyKey: string | Symbol,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {

--- a/lib/orm/decorators/listeners/before-update.decorator.ts
+++ b/lib/orm/decorators/listeners/before-update.decorator.ts
@@ -7,7 +7,7 @@ import {
 
 export function BeforeUpdate(): MethodDecorator {
   return (
-    target: object,
+    target: Function,
     propertyKey: string | Symbol,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {

--- a/lib/orm/decorators/user-defined-type-column.decorator.ts
+++ b/lib/orm/decorators/user-defined-type-column.decorator.ts
@@ -4,7 +4,7 @@ import { addAttribute } from '../utils/decorator.utils';
 export function UserDefinedTypeColumn(
   options: UserDefinedTypeColumnOptions,
 ): PropertyDecorator {
-  return (target: object, propertyName: string) => {
+  return (target: Function, propertyName: string) => {
     addAttribute(target, propertyName, options);
   };
 }

--- a/lib/orm/interfaces/externals/express-cassandra-connection.interface.ts
+++ b/lib/orm/interfaces/externals/express-cassandra-connection.interface.ts
@@ -17,7 +17,7 @@ export interface Connection extends FunctionConstructor {
 
   doBatchAsync(queries: string[]): Promise<any>;
 
-  loadSchema<T = any>(schema: any, name?: string): BaseModel<T>;
+  loadSchema<T = any>(name: string, schema: any): BaseModel<T>;
 
   instance: { [index: string]: BaseModel<any> };
 

--- a/lib/orm/utils/db.utils.ts
+++ b/lib/orm/utils/db.utils.ts
@@ -1,6 +1,6 @@
 import { types } from 'cassandra-driver';
 
-export const isUuid = (id: any): boolean => id && id instanceof types.Uuid;
+export const isUuid = (id: any): boolean => !!id && id instanceof types.Uuid;
 
 export const uuid = (id?: any): types.Uuid => {
   if (!id) {
@@ -13,7 +13,7 @@ export const uuid = (id?: any): types.Uuid => {
 };
 
 export const isTimeUuid = (id: any): boolean =>
-  id && id instanceof types.TimeUuid;
+  !!id && id instanceof types.TimeUuid;
 
 export const timeuuid = (idOrDate?: string | Date): types.TimeUuid => {
   if (!idOrDate) {

--- a/lib/orm/utils/decorator.utils.ts
+++ b/lib/orm/utils/decorator.utils.ts
@@ -8,53 +8,65 @@ import {
 } from '../../orm/orm.constant';
 import { mergeDeep } from '../../orm/utils/deep-merge.utils';
 
-export function setEntity(target: any, entity: Function): void {
+export function setEntity(target: Function, entity: Function): void {
   Reflect.defineMetadata(ENTITY_METADATA, entity, target);
 }
 
-export function getEntity(target: any): Function {
+export function getEntity(target: Function): Function {
   return Reflect.getMetadata(ENTITY_METADATA, target);
 }
 
-export function setEntityName(target: any, modelName: string): void {
+export function setEntityName(target: Function, modelName: string): void {
   Reflect.defineMetadata(ENTITY_NAME_KEY, modelName, target);
 }
 
-export function getEntityName(target: any): string {
+export function getEntityName(target: Function): string {
   return Reflect.getMetadata(ENTITY_NAME_KEY, target);
 }
 
-export function setUserDefinedTypeName(target: any, name: string): void {
+export function setUserDefinedTypeName(target: Function, name: string): void {
   Reflect.defineMetadata(USER_DEFINED_TYPE_NAME_KEY, name, target);
 }
 
-export function getUserDefinedTypeName(target: any): string {
+export function getUserDefinedTypeName(target: Function): string {
   return Reflect.getMetadata(USER_DEFINED_TYPE_NAME_KEY, target);
 }
 
-export function getAttributes(target: any): any | undefined {
+export function getAttributes(target: Function): Record<string, any> {
   const attributes = Reflect.getMetadata(ATTRIBUTE_KEY, target);
 
   if (attributes) {
-    return Object.keys(attributes).reduce((copy, key) => {
-      copy[key] = { ...attributes[key] };
-      return copy;
-    }, {});
+    return Object.keys(attributes).reduce(
+      (copy, key) => {
+        copy[key] = { ...attributes[key] };
+        return copy;
+      },
+      {} as Record<string, any>,
+    );
   }
+
+  return {};
 }
 
-export function setAttributes(target: Object, attributes: any) {
+export function setAttributes(
+  target: Function,
+  attributes: Record<string, any>,
+): void {
   Reflect.defineMetadata(ATTRIBUTE_KEY, { ...attributes }, target);
 }
 
-export function addAttribute(target: any, name: string, options: any): void {
-  const attributes = getAttributes(target) || {};
+export function addAttribute(
+  target: Function,
+  name: string,
+  options: any,
+): void {
+  const attributes = getAttributes(target);
   attributes[name] = { ...options };
   setAttributes(target, attributes);
 }
 
 export function addAttributeOptions(
-  target: any,
+  target: Function,
   propertyName: string,
   options: any,
 ): void {
@@ -63,21 +75,30 @@ export function addAttributeOptions(
   setAttributes(target, attributes);
 }
 
-export function getOptions(target: any): any | undefined {
+export function getOptions(target: Function): Record<string, any> {
   const options = Reflect.getMetadata(OPTIONS_KEY, target);
   return options ? { ...options } : {};
 }
 
-export function setOptions(target: any, options: any): void {
+export function setOptions(
+  target: Function,
+  options: Record<string, any>,
+): void {
   Reflect.defineMetadata(OPTIONS_KEY, { ...options }, target);
 }
 
-export function addOptions(target: any, options: any): void {
+export function addOptions(
+  target: Function,
+  options: Record<string, any>,
+): void {
   const mOptions = getOptions(target) || {};
   setOptions(target, mergeDeep(mOptions, options));
 }
 
-export const addHookFunction = (target: object, metadataKey: string) => {
+export const addHookFunction = (
+  target: Function,
+  metadataKey: string,
+): ((...args: any[]) => any[]) => {
   const funcLikeArray: any[] = Reflect.getMetadata(metadataKey, target) || [];
   return (...args: any[]) => funcLikeArray.map(funcLike => funcLike(...args));
 };

--- a/lib/orm/utils/model.utils.ts
+++ b/lib/orm/utils/model.utils.ts
@@ -1,10 +1,13 @@
 import { Logger } from '@nestjs/common';
 import { Connection } from '../interfaces';
-import { getAttributes, getOptions } from './decorator.utils';
+import { getAttributes, getEntityName, getOptions } from './decorator.utils';
 
-export function loadModel(connection: Connection, entity: any): Promise<any> {
+export function loadModel(
+  connection: Connection,
+  entity: Function,
+): Promise<any> {
   const schema = getSchema(entity);
-  const modelName = entity.name || entity.table_name;
+  const modelName = getEntityName(entity);
   const model = connection.loadSchema(modelName, schema);
 
   return new Promise(resolve => {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/jest": "^29.5.14",
     "@types/merge-deep": "^3.0.3",
     "@types/node": "10.12.18",
+    "@types/pluralize": "^0.0.33",
     "express-cassandra": "^2.9.1",
     "husky": "3.0.9",
     "jest": "^29.7.0",
@@ -55,7 +56,8 @@
     ]
   },
   "dependencies": {
-    "merge-deep": "^3.0.3"
+    "merge-deep": "^3.0.3",
+    "pluralize": "^8.0.0"
   },
   "keywords": [
     "nestjs",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express-cassandra": "^2.9.1",
     "husky": "3.0.9",
     "jest": "^29.7.0",
+    "jest-spec-reporter": "^1.0.19",
     "lint-staged": "9.4.2",
     "prettier": "1.18.2",
     "reflect-metadata": "^0.2.2",
@@ -82,6 +83,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "reporters": [
+      "default",
+      "jest-spec-reporter"
+    ]
   }
 }

--- a/test/orm/decorator/column-decorator.spec.ts
+++ b/test/orm/decorator/column-decorator.spec.ts
@@ -1,0 +1,5 @@
+describe('Column decorator', () => {
+  it('should be defined', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/test/orm/decorator/column-decorator.spec.ts
+++ b/test/orm/decorator/column-decorator.spec.ts
@@ -1,5 +1,0 @@
-describe('Column decorator', () => {
-  it('should be defined', () => {
-    expect(1 + 1).toBe(2);
-  });
-});

--- a/test/orm/decorators/entity-decorator.spec.ts
+++ b/test/orm/decorators/entity-decorator.spec.ts
@@ -1,0 +1,170 @@
+import { Entity } from '../../../lib/orm/decorators/entity.decorator';
+import { EntityOptions } from '../../../lib/orm/interfaces';
+import {
+  getEntityName,
+  getOptions,
+} from '../../../lib/orm/utils/decorator.utils';
+
+describe('Entity Decorator', () => {
+  it('should set entity name using class name in plural snake_case when no name provided', () => {
+    // Arrange & Act
+    @Entity()
+    class UserEntity {}
+
+    // Assert
+    expect(getEntityName(UserEntity)).toBe('user_entities');
+  });
+
+  it('should set entity name from string parameter', () => {
+    // Arrange & Act
+    @Entity('custom_users')
+    class UserEntity {}
+
+    // Assert
+    expect(getEntityName(UserEntity)).toBe('custom_users');
+  });
+
+  it('should set entity name from table_name option', () => {
+    // Arrange & Act
+    @Entity({ table_name: 'system_users' })
+    class UserEntity {}
+
+    // Assert
+    expect(getEntityName(UserEntity)).toBe('system_users');
+  });
+
+  it('should throw error when string name parameter and table_name option are provided', () => {
+    // Assert
+    expect(() => {
+      // Arrange & Act
+      @Entity('priority_users', { table_name: 'system_users' })
+      class UserEntity {}
+    }).toThrow(
+      'Cannot specify table name in both parameters. Use either string parameter or options.table_name, not both.',
+    );
+  });
+
+  it('should add instance and class methods to options', () => {
+    // Arrange & Act
+    @Entity()
+    class UserEntity {}
+
+    // Assert
+    const options = getOptions(UserEntity);
+    expect(options.instanceMethods).toBe(UserEntity.prototype);
+    expect(options.classMethods).toBe(UserEntity);
+  });
+
+  it('should merge provided options with instance and class methods', () => {
+    // Arrange
+    const options: EntityOptions = {
+      timestamps: true,
+      saveUnknown: false,
+    };
+
+    // Act
+    @Entity(options)
+    class UserEntity {}
+
+    // Assert
+    const resultOptions = getOptions(UserEntity);
+    expect(resultOptions).toEqual({
+      timestamps: true,
+      saveUnknown: false,
+      instanceMethods: UserEntity.prototype,
+      classMethods: UserEntity,
+    });
+  });
+
+  it('should handle both name and options parameters', () => {
+    // Arrange
+    const options: EntityOptions = {
+      timestamps: true,
+    };
+
+    // Act
+    @Entity('custom_users', options)
+    class UserEntity {}
+
+    // Assert
+    expect(getEntityName(UserEntity)).toBe('custom_users');
+    expect(getOptions(UserEntity)).toEqual({
+      timestamps: true,
+      instanceMethods: UserEntity.prototype,
+      classMethods: UserEntity,
+    });
+  });
+
+  it('should handle empty options', () => {
+    // Arrange & Act
+    @Entity({})
+    class UserEntity {}
+
+    // Assert
+    expect(getEntityName(UserEntity)).toBe('user_entities');
+    expect(getOptions(UserEntity)).toEqual({
+      instanceMethods: UserEntity.prototype,
+      classMethods: UserEntity,
+    });
+  });
+
+  it('should convert PascalCase class name to plural snake_case table name', () => {
+    // Arrange & Act
+    @Entity()
+    class UserProfileEntity {}
+
+    // Assert
+    expect(getEntityName(UserProfileEntity)).toBe('user_profile_entities');
+  });
+
+  it('should preserve existing options when adding methods', () => {
+    // Arrange
+    const complexOptions: EntityOptions = {
+      timestamps: true,
+      clusteringOrder: { createdAt: 'desc' },
+      indexes: ['email'],
+      table_name: 'complex_users',
+    };
+
+    // Act
+    @Entity(complexOptions)
+    class UserEntity {
+      public someMethod() {}
+      public static someStaticMethod() {}
+    }
+
+    // Assert
+    const resultOptions = getOptions(UserEntity);
+    expect(resultOptions).toEqual({
+      ...complexOptions,
+      instanceMethods: UserEntity.prototype,
+      classMethods: UserEntity,
+    });
+  });
+
+  it('should handle undefined options', () => {
+    // Arrange & Act
+    @Entity(undefined)
+    class UserEntity {}
+
+    // Assert
+    expect(getEntityName(UserEntity)).toBe('user_entities');
+    expect(getOptions(UserEntity)).toEqual({
+      instanceMethods: UserEntity.prototype,
+      classMethods: UserEntity,
+    });
+  });
+
+  it('should handle multiple decorations on different classes independently', () => {
+    // Arrange & Act
+    @Entity('users')
+    class UserEntity {}
+
+    @Entity('profiles')
+    class ProfileEntity {}
+
+    // Assert
+    expect(getEntityName(UserEntity)).toBe('users');
+    expect(getEntityName(ProfileEntity)).toBe('profiles');
+  });
+});

--- a/test/utils/db-utils.spec.ts
+++ b/test/utils/db-utils.spec.ts
@@ -1,0 +1,161 @@
+import { types } from 'cassandra-driver';
+import {
+  isTimeUuid,
+  isUuid,
+  timeuuid,
+  uuid,
+} from '../../lib/orm/utils/db.utils';
+
+describe('Database utils', () => {
+  describe('UUID functions', () => {
+    describe('isUuid', () => {
+      it('should return true for valid UUID instance', () => {
+        // Arrange
+        const validUuid = types.Uuid.random();
+
+        // Act & Assert
+        expect(isUuid(validUuid)).toBe(true);
+      });
+
+      it('should return false for non-UUID values', () => {
+        // Arrange
+        const invalidValues = ['not-a-uuid', 123, null, undefined, {}, []];
+
+        // Act & Assert
+        invalidValues.forEach(value => {
+          expect(isUuid(value)).toBe(false);
+        });
+      });
+    });
+
+    describe('uuid', () => {
+      it('should generate random UUID when no argument provided', () => {
+        // Act
+        const result = uuid();
+
+        // Assert
+        expect(result).toBeInstanceOf(types.Uuid);
+        expect(isUuid(result)).toBe(true);
+      });
+
+      it('should create UUID from valid string', () => {
+        // Arrange
+        const validUuidString = '123e4567-e89b-12d3-a456-426614174000';
+
+        // Act
+        const result = uuid(validUuidString);
+
+        // Assert
+        expect(result).toBeInstanceOf(types.Uuid);
+        expect(result.toString()).toBe(validUuidString);
+      });
+
+      it('should return the same UUID instance if one is provided', () => {
+        // Arrange
+        const existingUuid = types.Uuid.random();
+
+        // Act
+        const result = uuid(existingUuid);
+
+        // Assert
+        expect(result).toBe(existingUuid);
+      });
+
+      it('should throw error for invalid UUID string', () => {
+        // Arrange
+        const invalidUuidString = 'not-a-valid-uuid';
+
+        // Act & Assert
+        expect(() => uuid(invalidUuidString)).toThrow();
+      });
+    });
+  });
+
+  describe('TimeUUID functions', () => {
+    describe('isTimeUuid', () => {
+      it('should return true for valid TimeUUID instance', () => {
+        // Arrange
+        const validTimeUuid = types.TimeUuid.now();
+
+        // Act & Assert
+        expect(isTimeUuid(validTimeUuid)).toBe(true);
+      });
+
+      it('should return false for non-TimeUUID values', () => {
+        // Arrange
+        const invalidValues = [
+          'not-a-timeuuid',
+          123,
+          null,
+          undefined,
+          {},
+          [],
+          types.Uuid.random(), // Even regular Uuid should return false
+        ];
+
+        // Act & Assert
+        invalidValues.forEach(value => {
+          expect(isTimeUuid(value)).toBe(false);
+        });
+      });
+    });
+
+    describe('timeuuid', () => {
+      it('should generate TimeUUID for current time when no argument provided', () => {
+        // Act
+        const result = timeuuid();
+
+        // Assert
+        expect(result).toBeInstanceOf(types.TimeUuid);
+        expect(isTimeUuid(result)).toBe(true);
+      });
+
+      it('should create TimeUUID from valid string', () => {
+        // Arrange
+        const validTimeUuidString = types.TimeUuid.now().toString();
+
+        // Act
+        const result = timeuuid(validTimeUuidString);
+
+        // Assert
+        expect(result).toBeInstanceOf(types.TimeUuid);
+        expect(result.toString()).toBe(validTimeUuidString);
+      });
+
+      it('should create TimeUUID from Date object', () => {
+        // Arrange
+        const date = new Date();
+
+        // Act
+        const result = timeuuid(date);
+
+        // Assert
+        expect(result).toBeInstanceOf(types.TimeUuid);
+        expect(result.getDate().getTime()).toBe(date.getTime());
+      });
+
+      it('should throw error for invalid TimeUUID string', () => {
+        // Arrange
+        const invalidTimeUuidString = 'not-a-valid-timeuuid';
+
+        // Act & Assert
+        expect(() => timeuuid(invalidTimeUuidString)).toThrow();
+      });
+
+      it('should create different TimeUUIDs for different dates', () => {
+        // Arrange
+        const date1 = new Date('2023-01-01');
+        const date2 = new Date('2023-12-31');
+
+        // Act
+        const result1 = timeuuid(date1);
+        const result2 = timeuuid(date2);
+
+        // Assert
+        expect(result1.toString()).not.toBe(result2.toString());
+        expect(result1.getDate().getTime()).toBe(date1.getTime());
+        expect(result2.getDate().getTime()).toBe(date2.getTime());
+      });
+    });
+  });
+});

--- a/test/utils/decorator-utils.spec.ts
+++ b/test/utils/decorator-utils.spec.ts
@@ -1,0 +1,611 @@
+import {
+  addAttribute,
+  addAttributeOptions,
+  addHookFunction,
+  addOptions,
+  getAttributes,
+  getEntity,
+  getEntityName,
+  getOptions,
+  getUserDefinedTypeName,
+  setAttributes,
+  setEntity,
+  setEntityName,
+  setOptions,
+  setUserDefinedTypeName,
+} from '../../lib/orm/utils/decorator.utils';
+
+describe('Decorator utils', () => {
+  describe('Entity metadata', () => {
+    class TestEntity {}
+    class TargetClass {}
+
+    it('should set and get entity metadata correctly', () => {
+      // Arrange
+      const target = TargetClass;
+
+      // Act
+      setEntity(target, TestEntity);
+      const retrievedEntity = getEntity(target);
+
+      // Assert
+      expect(retrievedEntity).toBe(TestEntity);
+    });
+
+    it('should return undefined when getting entity metadata that was not set', () => {
+      // Arrange
+      const target = class EmptyClass {};
+
+      // Act
+      const retrievedEntity = getEntity(target);
+
+      // Assert
+      expect(retrievedEntity).toBeUndefined();
+    });
+
+    it('should override previous entity metadata when setting multiple times', () => {
+      // Arrange
+      const target = TargetClass;
+      class NewTestEntity {}
+
+      // Act
+      setEntity(target, TestEntity);
+      setEntity(target, NewTestEntity);
+      const retrievedEntity = getEntity(target);
+
+      // Assert
+      expect(retrievedEntity).toBe(NewTestEntity);
+      expect(retrievedEntity).not.toBe(TestEntity);
+    });
+
+    it('should store metadata on the correct target', () => {
+      // Arrange
+      const target1 = class Target1 {};
+      const target2 = class Target2 {};
+
+      // Act
+      setEntity(target1, TestEntity);
+
+      // Assert
+      expect(getEntity(target1)).toBe(TestEntity);
+      expect(getEntity(target2)).toBeUndefined();
+    });
+  });
+
+  describe('Entity name metadata', () => {
+    class TargetClass {}
+
+    it('should set and get entity name correctly', () => {
+      // Arrange
+      const target = TargetClass;
+      const entityName = 'TestEntityTable';
+
+      // Act
+      setEntityName(target, entityName);
+      const retrievedName = getEntityName(target);
+
+      // Assert
+      expect(retrievedName).toBe(entityName);
+    });
+
+    it('should return undefined when getting entity name that was not set', () => {
+      // Arrange
+      const target = class EmptyClass {};
+
+      // Act
+      const retrievedName = getEntityName(target);
+
+      // Assert
+      expect(retrievedName).toBeUndefined();
+    });
+
+    it('should override previous entity name when setting multiple times', () => {
+      // Arrange
+      const target = TargetClass;
+      const firstEntityName = 'FirstEntityTable';
+      const secondEntityName = 'SecondEntityTable';
+
+      // Act
+      setEntityName(target, firstEntityName);
+      setEntityName(target, secondEntityName);
+      const retrievedName = getEntityName(target);
+
+      // Assert
+      expect(retrievedName).toBe(secondEntityName);
+      expect(retrievedName).not.toBe(firstEntityName);
+    });
+
+    it('should store entity names independently for different targets', () => {
+      // Arrange
+      const target1 = class Target1 {};
+      const target2 = class Target2 {};
+      const entityName1 = 'EntityTable1';
+      const entityName2 = 'EntityTable2';
+
+      // Act
+      setEntityName(target1, entityName1);
+      setEntityName(target2, entityName2);
+
+      // Assert
+      expect(getEntityName(target1)).toBe(entityName1);
+      expect(getEntityName(target2)).toBe(entityName2);
+    });
+
+    it('should handle empty string as entity name', () => {
+      // Arrange
+      const target = TargetClass;
+      const emptyEntityName = '';
+
+      // Act
+      setEntityName(target, emptyEntityName);
+      const retrievedName = getEntityName(target);
+
+      // Assert
+      expect(retrievedName).toBe(emptyEntityName);
+    });
+  });
+
+  describe('User defined type name metadata', () => {
+    class TargetClass {}
+
+    it('should set and get user defined type name correctly', () => {
+      // Arrange
+      const target = TargetClass;
+      const userDefinedTypeName = 'TestUserDefinedType';
+
+      // Act
+      setUserDefinedTypeName(target, userDefinedTypeName);
+      const retrievedName = getUserDefinedTypeName(target);
+
+      // Assert
+      expect(retrievedName).toBe(userDefinedTypeName);
+    });
+
+    it('should return undefined when getting user defined type name that was not set', () => {
+      // Arrange
+      const target = class EmptyClass {};
+
+      // Act
+      const retrievedName = getUserDefinedTypeName(target);
+
+      // Assert
+      expect(retrievedName).toBeUndefined();
+    });
+
+    it('should override previous user defined type name when setting multiple times', () => {
+      // Arrange
+      const target = TargetClass;
+      const firstUserDefinedTypeName = 'FirstUserDefinedType';
+      const secondUserDefinedTypeName = 'SecondUserDefinedType';
+
+      // Act
+      setUserDefinedTypeName(target, firstUserDefinedTypeName);
+      setUserDefinedTypeName(target, secondUserDefinedTypeName);
+      const retrievedName = getUserDefinedTypeName(target);
+
+      // Assert
+      expect(retrievedName).toBe(secondUserDefinedTypeName);
+    });
+
+    it('should store user defined type names independently for different targets', () => {
+      // Arrange
+      const target1 = class Target1 {};
+      const target2 = class Target2 {};
+      const userDefinedTypeName1 = 'UserDefinedType1';
+      const userDefinedTypeName2 = 'UserDefinedType2';
+
+      // Act
+      setUserDefinedTypeName(target1, userDefinedTypeName1);
+      setUserDefinedTypeName(target2, userDefinedTypeName2);
+
+      // Assert
+      expect(getUserDefinedTypeName(target1)).toBe(userDefinedTypeName1);
+      expect(getUserDefinedTypeName(target2)).toBe(userDefinedTypeName2);
+    });
+
+    it('should handle empty string as user defined type name', () => {
+      // Arrange
+      const target = TargetClass;
+      const emptyUserDefinedTypeName = '';
+
+      // Act
+      setUserDefinedTypeName(target, emptyUserDefinedTypeName);
+      const retrievedName = getUserDefinedTypeName(target);
+
+      // Assert
+      expect(retrievedName).toBe(emptyUserDefinedTypeName);
+    });
+  });
+
+  describe('Attributes metadata', () => {
+    class TargetClass {}
+
+    it('should set and get attributes correctly', () => {
+      // Arrange
+      const target = TargetClass;
+      const attributes = {
+        name: { type: 'text' },
+        age: { type: 'int' },
+      };
+
+      // Act
+      setAttributes(target, attributes);
+      const retrievedAttributes = getAttributes(target);
+
+      // Assert
+      expect(retrievedAttributes).toEqual(attributes);
+    });
+
+    it('should return empty object when getting attributes that were not set', () => {
+      // Arrange
+      const target = class EmptyClass {};
+
+      // Act
+      const retrievedAttributes = getAttributes(target);
+
+      // Assert
+      expect(retrievedAttributes).toEqual({});
+    });
+
+    it('should add new attribute correctly', () => {
+      // Arrange
+      const target = TargetClass;
+      const attributeName = 'email';
+      const attributeOptions = { type: 'text', required: true };
+
+      // Act
+      addAttribute(target, attributeName, attributeOptions);
+      const retrievedAttributes = getAttributes(target);
+
+      // Assert
+      expect(retrievedAttributes[attributeName]).toEqual(attributeOptions);
+    });
+
+    it('should override existing attribute when adding with same name', () => {
+      // Arrange
+      const target = TargetClass;
+      const attributeName = 'email';
+      const initialOptions = { type: 'text' };
+      const newOptions = { type: 'varchar', required: true };
+
+      // Act
+      addAttribute(target, attributeName, initialOptions);
+      addAttribute(target, attributeName, newOptions);
+      const retrievedAttributes = getAttributes(target);
+
+      // Assert
+      expect(retrievedAttributes[attributeName]).toEqual(newOptions);
+    });
+
+    it('should merge attribute options correctly', () => {
+      // Arrange
+      const target = TargetClass;
+      const attributeName = 'email';
+      const initialOptions = { type: 'text', required: true };
+      const additionalOptions = { index: true, default: 'test@example.com' };
+      const expectedOptions = {
+        type: 'text',
+        required: true,
+        index: true,
+        default: 'test@example.com',
+      };
+
+      // Act
+      addAttribute(target, attributeName, initialOptions);
+      addAttributeOptions(target, attributeName, additionalOptions);
+      const retrievedAttributes = getAttributes(target);
+
+      // Assert
+      expect(retrievedAttributes[attributeName]).toEqual(expectedOptions);
+    });
+
+    it('should handle deep merging of attribute options', () => {
+      // Arrange
+      const target = TargetClass;
+      const attributeName = 'profile';
+      const initialOptions = {
+        type: 'map',
+        typeDef: { key: 'text', value: 'text' },
+      };
+      const additionalOptions = {
+        typeDef: { value: 'varchar' },
+        required: true,
+      };
+      const expectedOptions = {
+        type: 'map',
+        typeDef: { key: 'text', value: 'varchar' },
+        required: true,
+      };
+
+      // Act
+      addAttribute(target, attributeName, initialOptions);
+      addAttributeOptions(target, attributeName, additionalOptions);
+      const retrievedAttributes = getAttributes(target);
+
+      // Assert
+      expect(retrievedAttributes[attributeName]).toEqual(expectedOptions);
+    });
+
+    it('should maintain independent attributes for different targets', () => {
+      // Arrange
+      const target1 = class Target1 {};
+      const target2 = class Target2 {};
+      const attributes1 = { name: { type: 'text' } };
+      const attributes2 = { age: { type: 'int' } };
+
+      // Act
+      setAttributes(target1, attributes1);
+      setAttributes(target2, attributes2);
+
+      // Assert
+      expect(getAttributes(target1)).toEqual(attributes1);
+      expect(getAttributes(target2)).toEqual(attributes2);
+    });
+
+    it('should create a new instance of attributes on each get', () => {
+      // Arrange
+      const target = TargetClass;
+      const attributes = { name: { type: 'text' } };
+      setAttributes(target, attributes);
+
+      // Act
+      const retrieved1 = getAttributes(target);
+      const retrieved2 = getAttributes(target);
+
+      // Assert
+      expect(retrieved1).toEqual(retrieved2);
+      expect(retrieved1).not.toBe(retrieved2);
+    });
+  });
+
+  describe('Options metadata', () => {
+    class TargetClass {}
+
+    it('should set and get options correctly', () => {
+      // Arrange
+      const target = TargetClass;
+      const options = {
+        timestamps: true,
+        saveUnknown: false,
+      };
+
+      // Act
+      setOptions(target, options);
+      const retrievedOptions = getOptions(target);
+
+      // Assert
+      expect(retrievedOptions).toEqual(options);
+    });
+
+    it('should return empty object when getting options that were not set', () => {
+      // Arrange
+      const target = class EmptyClass {};
+
+      // Act
+      const retrievedOptions = getOptions(target);
+
+      // Assert
+      expect(retrievedOptions).toEqual({});
+    });
+
+    it('should merge new options with existing ones', () => {
+      // Arrange
+      const target = TargetClass;
+      const initialOptions = { timestamps: true, saveUnknown: false };
+      const additionalOptions = {
+        ttl: 86400,
+        clusteringOrder: { created: 'desc' },
+      };
+      const expectedOptions = {
+        timestamps: true,
+        saveUnknown: false,
+        ttl: 86400,
+        clusteringOrder: { created: 'desc' },
+      };
+
+      // Act
+      setOptions(target, initialOptions);
+      addOptions(target, additionalOptions);
+      const retrievedOptions = getOptions(target);
+
+      // Assert
+      expect(retrievedOptions).toEqual(expectedOptions);
+    });
+
+    it('should override existing options with new values', () => {
+      // Arrange
+      const target = TargetClass;
+      const initialOptions = { timestamps: true, ttl: 3600 };
+      const newOptions = { timestamps: false, ttl: 7200 };
+      const expectedOptions = { timestamps: false, ttl: 7200 };
+
+      // Act
+      setOptions(target, initialOptions);
+      setOptions(target, newOptions);
+      const retrievedOptions = getOptions(target);
+
+      // Assert
+      expect(retrievedOptions).toEqual(expectedOptions);
+    });
+
+    it('should handle deep merging of options', () => {
+      // Arrange
+      const target = TargetClass;
+      const initialOptions = {
+        timestamps: true,
+        indexes: {
+          name_idx: {
+            name: 'text',
+          },
+        },
+      };
+      const additionalOptions = {
+        indexes: {
+          name_idx: {
+            age: 'number',
+          },
+          email_idx: {
+            email: 'text',
+          },
+        },
+      };
+      const expectedOptions = {
+        timestamps: true,
+        indexes: {
+          name_idx: {
+            name: 'text',
+            age: 'number',
+          },
+          email_idx: {
+            email: 'text',
+          },
+        },
+      };
+
+      // Act
+      setOptions(target, initialOptions);
+      addOptions(target, additionalOptions);
+      const retrievedOptions = getOptions(target);
+
+      // Assert
+      expect(retrievedOptions).toEqual(expectedOptions);
+    });
+
+    it('should maintain independent options for different targets', () => {
+      // Arrange
+      const target1 = class Target1 {};
+      const target2 = class Target2 {};
+      const options1 = { timestamps: true };
+      const options2 = { saveUnknown: true };
+
+      // Act
+      setOptions(target1, options1);
+      setOptions(target2, options2);
+
+      // Assert
+      expect(getOptions(target1)).toEqual(options1);
+      expect(getOptions(target2)).toEqual(options2);
+    });
+
+    it('should create a new instance of options on each get', () => {
+      // Arrange
+      const target = TargetClass;
+      const options = { timestamps: true };
+      setOptions(target, options);
+
+      // Act
+      const retrieved1 = getOptions(target);
+      const retrieved2 = getOptions(target);
+
+      // Assert
+      expect(retrieved1).toEqual(retrieved2);
+      expect(retrieved1).not.toBe(retrieved2);
+    });
+
+    it('should handle adding options when none exist', () => {
+      // Arrange
+      const target = TargetClass;
+      const newOptions = { timestamps: true };
+
+      // Act
+      addOptions(target, newOptions);
+      const retrievedOptions = getOptions(target);
+
+      // Assert
+      expect(retrievedOptions).toEqual(newOptions);
+    });
+  });
+
+  describe('Hook Functions', () => {
+    class TargetClass {}
+    const HOOK_KEY = 'test:hook';
+
+    afterEach(() => {
+      Reflect.deleteMetadata(HOOK_KEY, TargetClass);
+    });
+
+    it('should execute hook functions with provided arguments', () => {
+      // Arrange
+      const target = TargetClass;
+      const hookFn1 = jest.fn(x => x + 1);
+      const hookFn2 = jest.fn(x => x * 2);
+      Reflect.defineMetadata(HOOK_KEY, [hookFn1, hookFn2], target);
+
+      // Act
+      const executeHooks = addHookFunction(target, HOOK_KEY);
+      const results = executeHooks(5);
+
+      // Assert
+      expect(hookFn1).toHaveBeenCalledWith(5);
+      expect(hookFn2).toHaveBeenCalledWith(5);
+      expect(results).toEqual([6, 10]);
+    });
+
+    it('should return empty array when no hooks are defined', () => {
+      // Arrange
+      const target = TargetClass;
+
+      // Act
+      const executeHooks = addHookFunction(target, HOOK_KEY);
+      const results = executeHooks('test');
+
+      // Assert
+      expect(results).toEqual([]);
+    });
+
+    it('should handle multiple arguments', () => {
+      // Arrange
+      const target = TargetClass;
+      const hookFn = jest.fn((x, y) => x + y);
+      Reflect.defineMetadata(HOOK_KEY, [hookFn], target);
+
+      // Act
+      const executeHooks = addHookFunction(target, HOOK_KEY);
+      const results = executeHooks(5, 3);
+
+      // Assert
+      expect(hookFn).toHaveBeenCalledWith(5, 3);
+      expect(results).toEqual([8]);
+    });
+
+    it('should execute multiple hooks in order', () => {
+      // Arrange
+      const target = TargetClass;
+      const executionOrder: number[] = [];
+      const hookFn1 = jest.fn(() => executionOrder.push(1));
+      const hookFn2 = jest.fn(() => executionOrder.push(2));
+      const hookFn3 = jest.fn(() => executionOrder.push(3));
+      Reflect.defineMetadata(HOOK_KEY, [hookFn1, hookFn2, hookFn3], target);
+
+      // Act
+      const executeHooks = addHookFunction(target, HOOK_KEY);
+      executeHooks();
+
+      // Assert
+      expect(executionOrder).toEqual([1, 2, 3]);
+    });
+
+    it('should maintain separate hooks for different metadata keys', () => {
+      // Arrange
+      const target = TargetClass;
+      const HOOK_KEY_1 = 'test:hook:1';
+      const HOOK_KEY_2 = 'test:hook:2';
+      const hookFn1 = jest.fn(() => 'hook1');
+      const hookFn2 = jest.fn(() => 'hook2');
+
+      Reflect.defineMetadata(HOOK_KEY_1, [hookFn1], target);
+      Reflect.defineMetadata(HOOK_KEY_2, [hookFn2], target);
+
+      // Act
+      const executeHooks1 = addHookFunction(target, HOOK_KEY_1);
+      const executeHooks2 = addHookFunction(target, HOOK_KEY_2);
+
+      const results1 = executeHooks1();
+      const results2 = executeHooks2();
+
+      // Assert
+      expect(results1).toEqual(['hook1']);
+      expect(results2).toEqual(['hook2']);
+    });
+  });
+});

--- a/test/utils/model-utils.spec.ts
+++ b/test/utils/model-utils.spec.ts
@@ -1,0 +1,185 @@
+import { Logger } from '@nestjs/common';
+import { Connection } from '../../lib/orm/interfaces';
+import * as decoratorUtils from '../../lib/orm/utils/decorator.utils';
+import { getSchema, loadModel } from '../../lib/orm/utils/model.utils';
+
+jest.mock('@nestjs/common', () => ({
+  Logger: {
+    error: jest.fn(),
+  },
+}));
+
+describe('Model utils', () => {
+  let mockConnection: Connection;
+  let mockModel: any;
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Mock model with syncDB method
+    mockModel = {
+      syncDB: jest.fn(),
+    };
+
+    // Mock connection with loadSchema method
+    mockConnection = {
+      loadSchema: jest.fn().mockReturnValue(mockModel),
+    } as any;
+
+    // Mock decorator utils
+    jest.spyOn(decoratorUtils, 'getAttributes');
+    jest.spyOn(decoratorUtils, 'getEntityName');
+    jest.spyOn(decoratorUtils, 'getOptions');
+  });
+
+  describe('loadModel', () => {
+    class TestEntity {}
+
+    it('should load schema and sync database successfully', async () => {
+      // Arrange
+      const entityName = 'TestModel';
+      (decoratorUtils.getEntityName as jest.Mock).mockReturnValue(entityName);
+      mockModel.syncDB.mockImplementation(cb => cb(null));
+
+      // Act
+      const result = await loadModel(mockConnection, TestEntity);
+
+      // Assert
+      expect(decoratorUtils.getEntityName).toHaveBeenCalledWith(TestEntity);
+      expect(mockConnection.loadSchema).toHaveBeenCalledWith(
+        entityName,
+        expect.any(Object),
+      );
+      expect(mockModel.syncDB).toHaveBeenCalled();
+      expect(result).toBe(mockModel);
+      expect(Logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should handle syncDB error and log it', async () => {
+      // Arrange
+      const error = new Error('Sync failed');
+      mockModel.syncDB.mockImplementation(cb => cb(error));
+
+      // Act
+      const result = await loadModel(mockConnection, TestEntity);
+
+      // Assert
+      expect(Logger.error).toHaveBeenCalledWith(
+        error.message,
+        error.stack,
+        'ExpressCassandraModule',
+      );
+      expect(result).toBe(mockModel);
+    });
+  });
+
+  describe('getSchema', () => {
+    class TestEntity {}
+
+    it('should create schema with attributes and options', () => {
+      // Arrange
+      const mockAttributes = {
+        name: { type: 'text' },
+        age: { type: 'int' },
+      };
+      const mockOptions = {
+        instanceMethods: {
+          someMethod: () => {},
+        },
+        classMethods: {
+          someStaticMethod: () => {},
+        },
+        timestamps: true,
+        saveUnknown: false,
+      };
+
+      (decoratorUtils.getAttributes as jest.Mock).mockReturnValue(
+        mockAttributes,
+      );
+      (decoratorUtils.getOptions as jest.Mock).mockReturnValue(mockOptions);
+
+      // Act
+      const schema = getSchema(TestEntity);
+
+      // Assert
+      expect(schema).toEqual({
+        timestamps: true,
+        saveUnknown: false,
+        fields: mockAttributes,
+      });
+      expect(schema).not.toHaveProperty('instanceMethods');
+      expect(schema).not.toHaveProperty('classMethods');
+    });
+
+    it('should handle empty attributes and options', () => {
+      // Arrange
+      (decoratorUtils.getAttributes as jest.Mock).mockReturnValue({});
+      (decoratorUtils.getOptions as jest.Mock).mockReturnValue({});
+
+      // Act
+      const schema = getSchema(TestEntity);
+
+      // Assert
+      expect(schema).toEqual({
+        fields: {},
+      });
+    });
+
+    it('should get attributes from entity prototype', () => {
+      // Arrange
+      class TestEntity {}
+
+      // Act
+      getSchema(TestEntity);
+
+      // Assert
+      expect(decoratorUtils.getAttributes).toHaveBeenCalledWith(
+        TestEntity.prototype,
+      );
+    });
+
+    it('should get options from entity prototype', () => {
+      // Arrange
+      class TestEntity {}
+
+      // Act
+      getSchema(TestEntity);
+
+      // Assert
+      expect(decoratorUtils.getOptions).toHaveBeenCalledWith(
+        TestEntity.prototype,
+      );
+    });
+
+    it('should merge complex options correctly', () => {
+      // Arrange
+      const mockAttributes = {
+        id: { type: 'uuid', default: { $db_function: 'uuid()' } },
+      };
+      const mockOptions = {
+        instanceMethods: { method1: () => {} },
+        classMethods: { method2: () => {} },
+        timestamps: true,
+        clusteringOrder: { createdAt: 'desc' },
+        indexes: ['name'],
+      };
+
+      (decoratorUtils.getAttributes as jest.Mock).mockReturnValue(
+        mockAttributes,
+      );
+      (decoratorUtils.getOptions as jest.Mock).mockReturnValue(mockOptions);
+
+      // Act
+      const schema = getSchema(TestEntity);
+
+      // Assert
+      expect(schema).toEqual({
+        timestamps: true,
+        clusteringOrder: { createdAt: 'desc' },
+        indexes: ['name'],
+        fields: mockAttributes,
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,6 +721,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
 
+"@types/pluralize@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/pluralize/-/pluralize-0.0.33.tgz#8ad9018368c584d268667dd9acd5b3b806e8c82a"
+  integrity sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
@@ -3293,6 +3298,11 @@ please-upgrade-node@^3.1.1, please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
+
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1134,6 +1134,14 @@ chai@^4.1.2:
     pathval "^1.1.1"
     type-detect "^4.1.0"
 
+chalk@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -2580,6 +2588,14 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
+jest-spec-reporter@^1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/jest-spec-reporter/-/jest-spec-reporter-1.0.19.tgz#0fc3c31ac738bd2eb642e1f3980207d9bf739415"
+  integrity sha512-fMzJO+B/7Gx+IAbi1AIoss4cRkGDegC3oHoXIqSDqEzh3VRtIUWbnJzhpV+r+jQm54Si/oGF4qE+utq+HVAEdA==
+  dependencies:
+    chalk "4.1.1"
+    moment "2.29.4"
+
 jest-util@^29.0.0, jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
@@ -2978,6 +2994,11 @@ mkdirp@^0.5.1:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+moment@2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Add automatic pluralization of table names using 'pluralize' package
- Add validation to prevent conflicting table name definitions
- Fix decorator metadata storage to use class instead of prototype
- Remove empty test file

BREAKING CHANGE: Entity decorator now stores metadata on class instead of prototype

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information